### PR TITLE
Allow specifying a horizontal justification for the legend labels using `legend_hjust`.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * Allow turning off bar outlines using `draw_outline` equal to `FALSE` for geom `"bar"` (#25).
 
+* Allow specifying a horizontal justification for the legend labels using `legend_hjust` (#30).
+
 # funkyheatmap 0.4.0
 
 ## BREAKING CHANGES

--- a/R/create_legends.R
+++ b/R/create_legends.R
@@ -18,7 +18,8 @@ create_generic_geom_legend <- function(
   labels,
   size,
   color,
-  position_args = position_arguments()
+  position_args = position_arguments(),
+  label_hjust = .5
 ) {
   geom <- match.arg(geom)
 
@@ -29,34 +30,30 @@ create_generic_geom_legend <- function(
   legend_space <- .2
 
   # compute sizes of geoms
-  geom_size_data <-
+  legend_data <-
     tibble(
       size_value = size,
       color_value = color,
       xmin = - size * legend_size / 2,
       xmax = size * legend_size / 2,
       ymin = - size * legend_size / 2,
-      ymax = size * legend_size / 2
+      ymax = size * legend_size / 2,
+      label = labels,
+      colour = color,
+      size = size,
+      label_hjust = label_hjust
     )
 
   if (geom == "funkyrect") {
-    geom_size_data <- geom_size_data %>%
+    legend_data <- legend_data %>%
       pmap_df(score_to_funky_rectangle)
   } else if (geom == "circle") {
-    geom_size_data <- geom_size_data %>%
+    legend_data <- legend_data %>%
       mutate(r = size / 2)
   }
 
-  # add metadata
-  geom_size_data <- geom_size_data %>%
-    mutate(
-      label = labels,
-      colour = color,
-      size = size
-    )
-
   # compute positions of geoms
-  geom_data <- geom_size_data %>%
+  geom_data <- legend_data %>%
     mutate(
       width = .data$xmax - .data$xmin,
       height = .data$ymax - .data$ymin,
@@ -85,15 +82,12 @@ create_generic_geom_legend <- function(
       fontface = "bold"
     ),
     geom_data %>%
-      filter(abs((.data$size_value * 10) %% 2) < 1e-10) %>%
       transmute(
+        xmin = .data$xmin,
+        xmax = .data$xmax,
         ymin = .data$ymin - 1,
         ymax = .data$ymin,
-        x = (.data$xmin + .data$xmax) / 2,
-        xwidth = pmax(.data$xmax - .data$xmin, .5),
-        xmin = .data$x - .data$xwidth / 2,
-        xmax = .data$x + .data$xwidth / 2,
-        hjust = .5,
+        hjust = .data$label_hjust,
         vjust = 0,
         label_value = as.character(.data$label)
       )
@@ -119,9 +113,18 @@ create_funkyrect_legend <- function(
   labels,
   size,
   color,
-  position_args = position_arguments()
+  position_args = position_arguments(),
+  label_hjust = .5
 ) {
-  create_generic_geom_legend(title, "funkyrect", labels, size, color, position_args)
+  create_generic_geom_legend(
+    title = title,
+    geom = "funkyrect",
+    labels = labels,
+    size = size,
+    color = color,
+    position_args = position_args,
+    label_hjust = label_hjust
+  )
 }
 
 #' Create a rect legend
@@ -134,9 +137,18 @@ create_rect_legend <- function(
   labels,
   size,
   color,
-  position_args = position_arguments()
+  position_args = position_arguments(),
+  label_hjust = .5
 ) {
-  create_generic_geom_legend(title, "rect", labels, size, color, position_args)
+  create_generic_geom_legend(
+    title = title,
+    geom = "rect",
+    labels = labels,
+    size = size,
+    color = color,
+    position_args = position_args,
+    label_hjust = label_hjust
+  )
 }
 
 #' Create a circle legend
@@ -149,9 +161,18 @@ create_circle_legend <- function(
   labels,
   size,
   color,
-  position_args = position_arguments()
+  position_args = position_arguments(),
+  label_hjust = .5
 ) {
-  create_generic_geom_legend(title, "circle", labels, size, color, position_args)
+  create_generic_geom_legend(
+    title = title,
+    geom = "circle",
+    labels = labels,
+    size = size,
+    color = color,
+    position_args = position_args,
+    label_hjust = label_hjust
+  )
 }
 
 #' Create a pie legend
@@ -171,7 +192,7 @@ create_pie_legend <- function(
   start_y <- 0
   row_height <- position_args$row_height
 
-  pie_legend_df <-
+  legend_data <-
     tibble(
       name = labels,
       fill = color
@@ -203,7 +224,7 @@ create_pie_legend <- function(
       fontface = "bold",
       colour = "black"
     ),
-    pie_legend_df %>%
+    legend_data %>%
       transmute(
         x = start_x + .5 + .data$lab_x,
         y = start_y - 2.75 + .data$lab_y,
@@ -222,7 +243,7 @@ create_pie_legend <- function(
       ymax = .data$y + .data$yheight * (1 - .data$vjust)
     )
 
-  pie_data <- pie_legend_df %>%
+  pie_data <- legend_data %>%
     transmute(
       x0 = start_x,
       y0 = start_y - 2.75,
@@ -233,7 +254,7 @@ create_pie_legend <- function(
       colour = .data$fill
     )
 
-  segment_data <- pie_legend_df %>%
+  segment_data <- legend_data %>%
     transmute(
       x = start_x + .data$xpt * .85,
       xend = start_x + .data$xpt * 1.1,

--- a/R/funky_heatmap.R
+++ b/R/funky_heatmap.R
@@ -124,10 +124,13 @@
 #'    The defaults depend on the selected geom.
 #'  * `values` (optional): Used as values for the text and image geoms.
 #'  * `label_width` (`numeric`, optional): The width of the labels
-#'    (only for `geom = "text"` or `geom = "image"`). Defaults to `1`
+#'    (only when geom is `text` or `pie`). Defaults to `1`
 #'    for text and `2` for images.
 #'  * `value_width` (`numeric`, optional): The width of the values
 #'    (only for `geom = "text"`). Defaults to `2`.
+#'  * `label_hjust` (`numeric`, optional): The horizontal alignment of the
+#'    labels (only when geom is `circle`, `rect` or `funkyrect`). 
+#'    Defaults to `0.5`.
 #'
 #' @param position_args Sets parameters that affect positioning within a
 #' plot, such as row and column dimensions, annotation details, and the

--- a/R/score_to_funky_rectangle.R
+++ b/R/score_to_funky_rectangle.R
@@ -1,4 +1,4 @@
-score_to_funky_rectangle <- function(xmin, xmax, ymin, ymax, size_value, color_value) {
+score_to_funky_rectangle <- function(xmin, xmax, ymin, ymax, size_value, ...) {
   midpoint <- .8
 
   if (is.na(size_value)) {
@@ -25,5 +25,5 @@ score_to_funky_rectangle <- function(xmin, xmax, ymin, ymax, size_value, color_v
     ymax <- y + width / 2
   }
 
-  tibble(xmin, xmax, ymin, ymax, corner_size, size_value, color_value)
+  tibble(xmin, xmax, ymin, ymax, corner_size, size_value, ...)
 }

--- a/R/verify_legends.R
+++ b/R/verify_legends.R
@@ -189,6 +189,59 @@ verify_legends <- function(legends, palettes, column_info, data) {
       legend$color <- rep(legend$color, length(legend$labels))
     }
 
+    # check label_hjust
+    if (!legend %has_name% "label_hjust") {
+      legend$label_hjust <-
+        if (legend$geom %in% c("funkyrect", "rect", "circle")) {
+          .5
+        } else {
+          NULL
+        }
+    }
+    if (legend %has_name% "label_hjust") {
+      assert_that(
+        is.numeric(legend$label_hjust),
+        length(legend$label_hjust) == 1L || length(legend$label_hjust) == length(legend$labels)
+      )
+      if (length(legend$label_hjust) == 1L) {
+        legend$label_hjust <- rep(legend$label_hjust, length(legend$labels))
+      }
+    }
+
+    # check label_width
+    if (!legend %has_name% "label_width") {
+      legend$label_width <-
+        if (legend$geom == "text") {
+          1
+        } else if (legend$geom == "pie") {
+          2
+        } else {
+          NULL
+        }
+    }
+    if (legend %has_name% "label_width") {
+      assert_that(
+        is.numeric(legend$label_width),
+        length(legend$label_width) == 1L
+      )
+    }
+
+    # check value_width
+    if (!legend %has_name% "value_width") {
+      legend$value_width <-
+        if (legend$geom == "text") {
+          2
+        } else {
+          NULL
+        }
+    }
+    if (legend %has_name% "value_width") {
+      assert_that(
+        is.numeric(legend$value_width),
+        length(legend$value_width) == 1L
+      )
+    }
+
     legend
   })
 }

--- a/man/funky_heatmap.Rd
+++ b/man/funky_heatmap.Rd
@@ -128,10 +128,13 @@ The defaults depend on the selected geom.
 The defaults depend on the selected geom.
 \item \code{values} (optional): Used as values for the text and image geoms.
 \item \code{label_width} (\code{numeric}, optional): The width of the labels
-(only for \code{geom = "text"} or \code{geom = "image"}). Defaults to \code{1}
+(only when geom is \code{text} or \code{pie}). Defaults to \code{1}
 for text and \code{2} for images.
 \item \code{value_width} (\code{numeric}, optional): The width of the values
 (only for \code{geom = "text"}). Defaults to \code{2}.
+\item \code{label_hjust} (\code{numeric}, optional): The horizontal alignment of the
+labels (only when geom is \code{circle}, \code{rect} or \code{funkyrect}).
+Defaults to \code{0.5}.
 }}
 
 \item{position_args}{Sets parameters that affect positioning within a

--- a/man/verify_legends.Rd
+++ b/man/verify_legends.Rd
@@ -27,10 +27,13 @@ The defaults depend on the selected geom.
 The defaults depend on the selected geom.
 \item \code{values} (optional): Used as values for the text and image geoms.
 \item \code{label_width} (\code{numeric}, optional): The width of the labels
-(only for \code{geom = "text"} or \code{geom = "image"}). Defaults to \code{1}
+(only when geom is \code{text} or \code{pie}). Defaults to \code{1}
 for text and \code{2} for images.
 \item \code{value_width} (\code{numeric}, optional): The width of the values
 (only for \code{geom = "text"}). Defaults to \code{2}.
+\item \code{label_hjust} (\code{numeric}, optional): The horizontal alignment of the
+labels (only when geom is \code{circle}, \code{rect} or \code{funkyrect}).
+Defaults to \code{0.5}.
 }}
 
 \item{palettes}{A named list of palettes. Each entry in \code{column_info$palette}


### PR DESCRIPTION
Allow specifying a horizontal justification for the legend labels using `legend_hjust`.